### PR TITLE
Ad rule default hash + Adjusted existing rules

### DIFF
--- a/src/rootcheck/db/system_audit_pw.txt
+++ b/src/rootcheck/db/system_audit_pw.txt
@@ -26,27 +26,44 @@
 #
 # Checks for Password Security on Linux Systems
 #
+#1 Set Default Algorithm for Password Encryption to SHA256 or SHA 512
+[Password Hardening - 1: Set Default Algorithm for Password Encryption to SHA256 or SHA 512] [any] [https://security.stackexchange.com/questions/77349/how-can-i-find-out-the-password-hashing-schemes-used-by-the-specific-unix-accoun, https://docs.oracle.com/cd/E26505_01/html/E27224/secsystask-42.html]
+f:/etc/security/policy.conf -> !r:^# && r:^CRYPT_DEFAULT=1|^CRYPT_DEFAULT=2|^CRYPT_DEFAULT=2a|^CRYPT_DEFAULT=2x|^CRYPT_DEFAULT=2y|^CRYPT_DEFAULT=md5|^CRYPT_DEFAULT=__unix__;
+f:/etc/security/policy.conf -> !r:^CRYPT_DEFAULT=\d;
+f:/etc/login.defs -> !r:^# && r:^ENCRYPT_METHOD\s+MD5|^ENCRYPT_METHOD\s+DES;
+f:/etc/login.defs -> !r:^ENCRYPT_METHOD\s+SHA512|^ENCRYPT_METHOD\s+SHA256;
+f:/etc/pam.d/common-password -> !r:^# && r:password\.+pam_unix.so\.+md5|password\.+pam_unix.so\.+des;
+f:/etc/pam.d/common-password -> !r:^password\.+pam_unix.so\.+sha512|^password\.+pam_unix.so\.+sha256;
+f:/etc/pam.d/password-auth -> !r:^# && r:password\.+pam_unix.so\.+md5|password\.+pam_unix.so\.+des;
+f:/etc/pam.d/password-auth -> !r:^password\.+pam_unix.so\.+sha512|^password\.+pam_unix.so\.+sha256;
+f:/etc/pam.d/system-auth -> !r:^# && r:password\.+pam_unix.so\.+md5|password\.+pam_unix.so\.+des;
+f:/etc/pam.d/system-auth -> !r:^password\.+pam_unix.so\.+sha512|^password\.+pam_unix.so\.+sha256;
+f:/etc/pam.d/system-auth-ac -> !r:^# && r:password\.+pam_unix.so\.+md5|password\.+pam_unix.so\.+des;
+f:/etc/pam.d/system-auth-ac -> !r:^password\.+pam_unix.so\.+sha512|^password\.+pam_unix.so\.+sha256;
 #
-#1 Passwords in /etc/shadow not hashed with SHA-256 or SHA-512
-[Password Hardening - 1: Not all Passwords in /etc/shadow are hashed with SHA-256 or SHA-512] [any] [https://linux-audit.com/password-security-with-linux-etc-shadow-file/, https://docs.oracle.com/cd/E19253-01/816-4557/concept-23/index.html]
+#
+#2 Passwords in /etc/shadow not hashed with SHA-256 or SHA-512
+[Password Hardening - 2: Not all Passwords in /etc/shadow are hashed with SHA-256 or SHA-512] [any] [https://linux-audit.com/password-security-with-linux-etc-shadow-file/, https://docs.oracle.com/cd/E19253-01/816-4557/concept-23/index.html]
 f:/etc/shadow -> !r:^# && !r:^\w+:NP:\d+:\d*:\d*:\d*:\d*:\d*:\d*$ && r:^\w+:\w\.*:\d+:\d*:\d*:\d*:\d*:\d*:\d*$;
-f:/etc/shadow -> !r:^# && r:\w+:$1$\.+;
-f:/etc/shadow -> !r:^# && r:\w+:$2$\.+;
-f:/etc/shadow -> !r:^# && r:\w+:$2a$\.+;
-f:/etc/shadow -> !r:^# && r:\w+:$2x$\.+;
-f:/etc/shadow -> !r:^# && r:\w+:$2y$\.+;
-f:/etc/shadow -> !r:^# && r:\w+:$md5$\.+;
-f:/etc/shadow -> !r:^# && r:\w+:$__unix__$\.+;
+f:/etc/shadow -> !r:^# && r:\w+:\$1\$\.+;
+f:/etc/shadow -> !r:^# && r:\w+:\$2\$\.+;
+f:/etc/shadow -> !r:^# && r:\w+:\$2a\$\.+;
+f:/etc/shadow -> !r:^# && r:\w+:\$2x\$\.+;
+f:/etc/shadow -> !r:^# && r:\w+:\$2y\$\.+;
+f:/etc/shadow -> !r:^# && r:\w+:\$md5\$\.+;
+f:/etc/shadow -> !r:^# && r:\w+:\$__unix__\$\.+;
 #
 #
-#2 Set Password Creation Requirement Parameters
-[Password Hardening - 2: Set Password Creation Requirement Parameters] [any] [https://linux-audit.com/configure-the-minimum-password-length-on-linux-systems/, https://workbench.cisecurity.org]
+#3 Set Password Creation Requirement Parameters
+[Password Hardening - 3: Set Password Creation Requirement Parameters] [any] [https://linux-audit.com/configure-the-minimum-password-length-on-linux-systems/, https://workbench.cisecurity.org]
 f:/etc/pam.d/common-password -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_pwquality.so\.+try_first_pass;
 f:/etc/pam.d/common-password -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_pwquality.so\.+retry=\d+;
 f:/etc/pam.d/password-auth -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_pwquality.so\.+try_first_pass;
 f:/etc/pam.d/password-auth -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_pwquality.so\.+retry=\d+;
 f:/etc/pam.d/system-auth -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_pwquality.so\.+try_first_pass;
 f:/etc/pam.d/system-auth -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_pwquality.so\.+retry=\d+;
+f:/etc/pam.d/system-auth-ac -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_pwquality.so\.+try_first_pass;
+f:/etc/pam.d/system-auth-ac -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_pwquality.so\.+retry=\d+;
 f:/etc/pam.d/passwd -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_cracklib.so\.+try_first_pass|^password\s*\t*required\s*\t*pam_pwquality.so\.+try_first_pass|^@include\s+common-password;
 f:/etc/pam.d/passwd -> !r:^password\s*\t*requisite\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*requisite\s*\t*pam_pwquality.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_cracklib.so\.+retry=\d+|^password\s*\t*required\s*\t*pam_pwquality.so\.+retry=\d+|^@include\s+common-password;
 f:/etc/pam.d/common-password -> r:pam_cracklib.so && !r:minlen=\d\d+;


### PR DESCRIPTION
Added rule for default password encryption setting and adjusted rule numbers 
Added missing character escaping for $s at rule 2. 
Added /etc/pam.d/system-auth-ac file to rule 3, needed for Fedora.